### PR TITLE
chore(node): resolve active LTS from the official nodejs API

### DIFF
--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -22,8 +22,14 @@ jobs:
         id: info
         run: |
           OLD_VERSION=$(<.nvmrc)
-          NEW_VERSION=$(curl -sSf https://resolve-node.vercel.app/lts)
-          NEW_VERSION=${NEW_VERSION#'v'}
+          INDEX_URL=https://nodejs.org/dist/index.json
+          LATEST_LTS=$(curl -sSf "$INDEX_URL" | jq -r '
+            [.[] | select(.lts != false)] |
+            sort_by(.version | ltrimstr("v") | split(".") | map(tonumber)) |
+            last |
+            .version
+          ')
+          NEW_VERSION=${LATEST_LTS#v}
           NEW_VERSION=${NEW_VERSION%%.*}
           UPDATE_TITLE="chore(node): bump from $OLD_VERSION to $NEW_VERSION"
           UPDATE_BODY="Bump Node from $OLD_VERSION to $NEW_VERSION."


### PR DESCRIPTION
Switches the update-node workflow to resolve the active LTS from the official nodejs API. The active LTS is selected by filtering entries where `lts` is not `false`, sorting by version, and taking the latest.